### PR TITLE
grammar: message to allow either value or traits

### DIFF
--- a/ftl/grammar.ebnf
+++ b/ftl/grammar.ebnf
@@ -14,8 +14,9 @@ builtin              ::= [A-Z_.?-];
 number               ::= [0-9]+ ('.' [0-9]+)?;
 member               ::= '*'? '[' keyword ']' __ pattern NL;
 
-message              ::= identifier __ value? __ trait*;
-value                ::= '=' __ pattern;
+message              ::= identifier __ '=' __ (value | trait-list);
+value                ::= pattern;
+trait-list           ::= NL (__ trait NL)+ __ trait?;
 trait                ::= member;
 
 pattern              ::= unquoted-pattern


### PR DESCRIPTION
This moves the grammar closer to accepting:

```
foo = bar
```

```
goo =
*[def] bar
[efg] car
```

```
hoo =
  *[def] dar
   [efg] car
```

The previous version accepted traits only on the same line as key with possible value in between:

```
goo = "what does this value mean?" *[def] bar
[efg] car
```

Also added support for whitespace before the trait.
