### PR TITLE
grammar: add quantifiers for keyword and builtin

### DIFF
--- a/ftl/grammar.ebnf
+++ b/ftl/grammar.ebnf
@@ -9,8 +9,8 @@ NL                   ::= [\r\n]+
 
 identifier           ::= [a-zA-Z_.?-] ([a-zA-Z0-9_.?-])*;
 variable             ::= '$' identifier;
-keyword              ::= [^=|#{}\[\]()];
-builtin              ::= [A-Z_.?-];
+keyword              ::= [^=|#{}\[\]()]+;
+builtin              ::= [A-Z_.?-]+;
 number               ::= [0-9]+ ('.' [0-9]+)?;
 member               ::= '*'? '[' keyword ']' __ pattern NL;
 


### PR DESCRIPTION
keyword and builtin were defined as single character whereas `+` was probably meant.
